### PR TITLE
Fix wrong admin link in Warpdrive top menu

### DIFF
--- a/src/class-savvii-dashboard.php
+++ b/src/class-savvii-dashboard.php
@@ -46,7 +46,7 @@ class SavviiDashboard {
             $wp_admin_bar->add_menu([
                 'id' => 'warpdrive_top_menu',
                 'title' => 'Savvii',
-                'href' => wp_nonce_url( 'options-general.php?page=warpdrive_dashboard' ),
+                'href' => wp_nonce_url( admin_url( 'options-general.php?page=warpdrive_dashboard' ) ),
             ]);
         }
     }

--- a/warpdrive.php
+++ b/warpdrive.php
@@ -3,7 +3,7 @@
  * Plugin name: Warpdrive
  * Plugin URI: https://github.com/Savvii/warpdrive
  * Description: Hosting plugin for Savvii
- * Version: 2.9.0
+ * Version: 2.9.1
  * Author: Savvii <support@savvii.com>
  * Author URI: https://www.savvii.com
  * License: GPL-3.0-only


### PR DESCRIPTION
Fix the Warpdrive top menu link in wordpress site.