### PR TITLE
[Fix] Validate if response is array before checking array key

### DIFF
--- a/src/class-api-response.php
+++ b/src/class-api-response.php
@@ -46,10 +46,6 @@ class ApiResponse {
      * @return string
      */
     function get_body() {
-        $body = '';
-        if (array_key_exists('body', $this->response))
-            $body = $this->response['body'];
-
-        return $body;
+        return (is_array($this->response) && array_key_exists('body', $this->response)) ? $this->response['body'] : '';
     }
 }


### PR DESCRIPTION
This is a fix for the following error:

```
PHP Fatal error:  Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, WP_Error given in <redacted>/wordpress/current/wp-content/plugins/warpdrive/src/class-api-response.php:50
```